### PR TITLE
Set smart punctuation config for French

### DIFF
--- a/config/public.php
+++ b/config/public.php
@@ -66,12 +66,12 @@ return [
         ],
 
         'locales' => [
-            //Locales::FRENCH->value => [
-            //    'double_quote_opener' => '“',
-            //    'double_quote_closer' => '”',
-            //    'single_quote_opener' => '‘',
-            //    'single_quote_closer' => '’',
-            //],
+            Locales::FRENCH->value => [
+               'double_quote_opener' => '« ', // followed by an UTF-8 non breack space
+               'double_quote_closer' => ' »', // preceded by an UTF-8 non breack space
+               'single_quote_opener' => '’',
+               'single_quote_closer' => '’',
+            ],
 
             Locales::RUSSIAN->value => [
                 'double_quote_opener' => '«',

--- a/config/public.php
+++ b/config/public.php
@@ -67,10 +67,10 @@ return [
 
         'locales' => [
             Locales::FRENCH->value => [
-               'double_quote_opener' => '« ', // followed by an UTF-8 non breack space
-               'double_quote_closer' => ' »', // preceded by an UTF-8 non breack space
-               'single_quote_opener' => '’',
-               'single_quote_closer' => '’',
+                'double_quote_opener' => '« ', // followed by an UTF-8 non breack space
+                'double_quote_closer' => ' »', // preceded by an UTF-8 non breack space
+                'single_quote_opener' => '‘',
+                'single_quote_closer' => '’',
             ],
 
             Locales::RUSSIAN->value => [


### PR DESCRIPTION
Definition of typographic characters for French.

> En français de France, les guillemets sont comptés comme des ponctuations hautes, et en tant que telles appellent l’usage d’espaces insécables après le guillemet ouvrant et avant le guillemet fermant.
src: https://fr.wikipedia.org/wiki/Guillemet

> In French from France, quotation marks are counted as high punctuation, and as such call for the use of non-breaking spaces after the opening quotation mark and before the closing quotation mark.