### PR TITLE
Allow HTML when smart_punctuation option is enabled

### DIFF
--- a/config/public.php
+++ b/config/public.php
@@ -67,8 +67,8 @@ return [
 
         'locales' => [
             Locales::FRENCH->value => [
-                'double_quote_opener' => '« ', // followed by an UTF-8 non breack space
-                'double_quote_closer' => ' »', // preceded by an UTF-8 non breack space
+                'double_quote_opener' => '«&nbsp;',
+                'double_quote_closer' => '&nbsp;»',
                 'single_quote_opener' => '‘',
                 'single_quote_closer' => '’',
             ],

--- a/src/Services/Converters/Text/SmartPunctuationDecorator.php
+++ b/src/Services/Converters/Text/SmartPunctuationDecorator.php
@@ -55,7 +55,7 @@ class SmartPunctuationDecorator extends BaseDecorator
     {
         return new Environment([
             'smartpunct' => $smartpunct,
-            'html_input' => HtmlFilter::STRIP,
+            'html_input' => HtmlFilter::ALLOW,
             'renderer'   => [
                 'block_separator' => Expect::string(),
                 'inner_separator' => Expect::string(),


### PR DESCRIPTION
Change Environment MarkdownConverter configuration to allow HTML. Because when the smart_punctuation option is activated, all HTML strings are escaped while this is not the case when it is deactivated.

Replaced UTF 8 non break spaces by HTML entity for french double quotes.