### PR TITLE
Fix infinite loop during array decorator call

### DIFF
--- a/src/Concerns/Decorator.php
+++ b/src/Concerns/Decorator.php
@@ -23,7 +23,7 @@ trait Decorator
     {
         foreach ($values as &$value) {
             if (is_array($value)) {
-                $value = $this->decorate($locale, $values);
+                $value = $this->decorate($locale, $value);
 
                 continue;
             }


### PR DESCRIPTION
If you call `php artisan lang:update` and your value has an array in it, the `Decorator` will call itself with the same parameters. I think this was supposed to be called with the `$value` not the whole `$values` array.